### PR TITLE
Refresh docs for the interfaces + Frankfurter wiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,18 +57,18 @@ di/              (Hilt modules)
   - `LruCache<K, V>` — `LinkedHashMap(accessOrder = true)` + `removeEldestEntry` override. Synchronized.
 
 - **Algorithms** (`core/algorithm/`):
-  - `PathFindingStrategy` (`fun interface`) + `AbstractPathFindingStrategy` (Template Method base) + `StrategyKind` enum + `StrategyFactory` (Hilt-multibound) + `StrategyChain` (Chain of Responsibility).
+  - `PathFindingStrategy` (`fun interface`) + `AbstractPathFindingStrategy` (Template Method base) + `StrategyKind` enum + `StrategyFactory` (interface, with `DefaultStrategyFactory` as the Hilt-multibound impl) + `StrategyChain` (Chain of Responsibility).
   - Five implementations, each documented at the top of its file with the intuition, the complexity, and any precondition: `DirectLookupStrategy`, `BfsPathFindingStrategy`, `DijkstraPathFindingStrategy` (max-product variant; requires arbitrage-free graph), `BellmanFordPathFindingStrategy` (handles arbitrage via `-ln(rate)` transform), `FloydWarshallPathFindingStrategy` (O(V³) precompute cached per graph instance).
 
 - **Data layer** (`data/`):
-  - `ExchangeRatesDataSource` interface with `EmbeddedExchangeRatesDataSource` (default) and `RemoteExchangeRatesDataSource` (Retrofit + Moshi codegen DTOs in `data/remote/dto/`).
+  - `ExchangeRatesDataSource` interface with `EmbeddedExchangeRatesDataSource` (default) and `RemoteExchangeRatesDataSource` backed by the Frankfurter API (`https://api.frankfurter.dev/v1/latest?base=USD`). DTOs in `data/remote/dto/`.
   - `ExchangeRatesRepository` interface, `DefaultExchangeRatesRepository` (uses `MutableStateFlow<CurrencyGraph?>` + `onSubscription` for lazy first-fetch + `Mutex`-guarded refresh), and `CachingExchangeRatesRepository` (Decorator over the default).
 
 - **Use cases + Facade** (`domain/usecase/`):
   - `ConvertCurrencyUseCase` — picks a strategy via `StrategyFactory.get(kind)` and shapes the result. Same-currency goes through the identity-path branch (empty `ConversionPath`).
   - `DetectArbitrageUseCase` — Bellman-Ford from each vertex; canonicalises cycle rotations to dedupe; filters cycles whose profit factor is within `EPSILON = 1e-3`.
   - `GetReachableCurrenciesUseCase` — builds a UnionFind from edges and returns `componentOf(source) - source`.
-  - `ConversionFacade` — the single collaborator the ViewModel knows about. Hides the three use cases behind a Facade (GoF).
+  - `ConversionFacade` — interface; `DefaultConversionFacade` is the Hilt-bound impl. The single collaborator the ViewModel knows about. Hides the three use cases behind a Facade (GoF).
 
 - **UI** (`ui/conversion/`, `ui/theme/`):
   - `MainActivity` (single-activity, edge-to-edge) hosts `ConversionScreen`.
@@ -89,7 +89,8 @@ di/              (Hilt modules)
 ### DI wiring (Hilt)
 
 - `AlgorithmModule` — multi-binds every `PathFindingStrategy` into `Map<StrategyKind, PathFindingStrategy>` via `@IntoMap` + custom `@StrategyKey` `@MapKey`. Adding a sixth algorithm is one line in this module.
-- `DataModule` — binds `ExchangeRatesDataSource` to embedded by default; swap to `RemoteExchangeRatesDataSource` is a one-line change.
+- `DataModule` — binds `ExchangeRatesDataSource` to `EmbeddedExchangeRatesDataSource` by default; flipping the target to `RemoteExchangeRatesDataSource` (one `@Binds` parameter) switches the app to live Frankfurter rates. Embedded stays the default because Frankfurter is strictly arbitrage-free and produces a hub-and-spoke graph — the embedded dataset's arbitrage triangle and multi-hop optima are what make the algorithm showcase interesting.
+- `DomainModule` — binds `ConversionFacade` to `DefaultConversionFacade`.
 - `NetworkModule` — Retrofit + Moshi + OkHttp; only exercised when the remote data source is bound.
 - `CoroutineModule` — production `DispatcherProvider`.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A single-screen Android app rebuilt as a teaching reference for graph algorithms, classic data structures, and Gang of Four design patterns. It happens to convert currencies because the rate table is a natural graph.
 
-Not a production app. No live backend, no auth, no analytics — the rate data is hand-curated and intentionally contains an arbitrage triangle so Bellman-Ford has something to find on first launch.
+Not a production app. No auth, no analytics. A live backend (Frankfurter, https://www.frankfurter.dev/) *is* wired up but isn't the default — the embedded rate dataset is hand-curated and intentionally contains an arbitrage triangle so Bellman-Ford has something to find on first launch.
 
 The intended audience is a candidate studying for an interview, or an interviewer who wants something concrete to pick apart. Every algorithm carries step-by-step pedagogical comments. Every Gang of Four pattern is wired live; nothing is in the repo "for show".
 
@@ -43,13 +43,13 @@ Switching strategies in the UI lets you see how each one picks a different path 
 | Pattern | Where to look |
 |---|---|
 | **Strategy** | `core/algorithm/PathFindingStrategy.kt` + five implementations |
-| **Factory** | `core/algorithm/StrategyFactory.kt` (Hilt-multibound `Map<StrategyKind, PathFindingStrategy>`) |
+| **Factory** | `core/algorithm/StrategyFactory.kt` — interface, `DefaultStrategyFactory` impl wired via Hilt-multibound `Map<StrategyKind, PathFindingStrategy>` |
 | **Template Method** | `core/algorithm/AbstractPathFindingStrategy.kt` — guards `findPath`, subclasses implement `search` |
 | **Chain of Responsibility** | `core/algorithm/StrategyChain.kt` — first non-null wins (Direct → BFS → Dijkstra → Bellman-Ford) |
 | **Builder** | `core/ds/CurrencyGraph.Builder` — fluent, validating, single-shot, returns an immutable graph |
 | **Decorator** | `data/repository/CachingExchangeRatesRepository.kt` — wraps `DefaultExchangeRatesRepository`, wired live in `DataModule` |
 | **Adapter** | `data/remote/dto/ExchangeRatesDto.toDomain()` — DTO ↔ domain bridge, keeps Moshi annotations off domain models |
-| **Facade** | `domain/usecase/ConversionFacade.kt` — single seam between ViewModel and the use-case subsystem |
+| **Facade** | `domain/usecase/ConversionFacade.kt` — interface; `DefaultConversionFacade` is the impl. Single seam between ViewModel and the use-case subsystem |
 | **Singleton** | Hilt `@Singleton` scopes throughout `di/` |
 | **Observer** | Repository → ViewModel via `StateFlow`/`Flow` |
 | **State** | `ui/conversion/ConversionUiState` sealed interface — exhaustive `when` in Compose |
@@ -98,7 +98,7 @@ Law of Demeter is taken seriously: the ViewModel knows about `ConversionFacade` 
 | UI | Jetpack Compose (BOM 2024.12) + Material 3, dynamic colour on API 31+ |
 | DI | Hilt 2.53.1 (KSP, no kapt) |
 | Async | Coroutines 1.10.1 + StateFlow |
-| Network | Retrofit 2.11 + Moshi 1.15 codegen + OkHttp logging (only used if you swap in `RemoteExchangeRatesDataSource`) |
+| Network | Retrofit 2.11 + Moshi 1.15 codegen + OkHttp logging; backend is [Frankfurter](https://www.frankfurter.dev/) (free, no API key, ECB-backed). Only used when `RemoteExchangeRatesDataSource` is bound. |
 | Test | JUnit 4, Turbine, MockK, kotlinx-coroutines-test |
 
 ---
@@ -123,7 +123,7 @@ Law of Demeter is taken seriously: the ViewModel knows about `ConversionFacade` 
 ./gradlew :app:lint
 ```
 
-To run against a real backend instead of the embedded dataset, change one binding in `di/DataModule.kt`:
+To run against the live [Frankfurter](https://www.frankfurter.dev/) API instead of the embedded dataset, change one binding in `di/DataModule.kt`:
 
 ```kotlin
 abstract fun bindDataSource(impl: EmbeddedExchangeRatesDataSource): ExchangeRatesDataSource
@@ -131,6 +131,8 @@ abstract fun bindDataSource(impl: EmbeddedExchangeRatesDataSource): ExchangeRate
 ```
 
 Repository, use cases, ViewModel, and UI need no changes — that's the payoff of coding to the interface.
+
+A heads-up about the trade-off: Frankfurter is ECB reference data, so it's strictly arbitrage-free and quotes one base against ~30 currencies, which produces a hub-and-spoke graph (every conversion is 1 or 2 hops via USD). The arbitrage card disappears and Dijkstra/Bellman-Ford/Floyd-Warshall all collapse to roughly the same answer. Useful for proving the swap works; less useful for showcasing what the algorithms can do — which is why embedded is the default.
 
 ---
 


### PR DESCRIPTION
## Summary

Two corrections to `README.md` and `CLAUDE.md`:

- `StrategyFactory` and `ConversionFacade` are now **interfaces** (with `DefaultStrategyFactory` and `DefaultConversionFacade` as the Hilt-bound impls). Both docs still described them as concrete classes — a real "code to abstraction" gap in the documentation.
- The "run against a real backend" sections didn't name **Frankfurter** even though it's wired. Now they spell out `https://api.frankfurter.dev/v1/latest?base=USD`, the free / ECB-backed nature, and the trade-off (arbitrage-free, hub-and-spoke graph) — which is why `Embedded` remains the default `DataModule` binding.

Also:
- Mention the new `DomainModule` (binds the facade).
- Tighten the "no live backend" line in the README — one *is* wired, just not bound.

## Test plan

- [x] Docs render correctly (Markdown, no broken links)
- [x] Code references still accurate (no symbol drift)
